### PR TITLE
Provide defaults

### DIFF
--- a/src/Bex/Behat/Magento2InitExtension/Fixtures/MagentoConfigManager.php
+++ b/src/Bex/Behat/Magento2InitExtension/Fixtures/MagentoConfigManager.php
@@ -58,6 +58,15 @@ class MagentoConfigManager extends BaseFixture
     public function changeConfigs(array $configs)
     {
         foreach ($configs as $config) {
+            
+            if (!array_key_exists('scope_type', $config)) {
+                $config['scope_type'] = ScopeConfigInterface::SCOPE_TYPE_DEFAULT;
+            }
+
+            if (!array_key_exists('scope_code', $config)) {
+                $config['scope_code'] = null;
+            }            
+            
             if ($this->isValidConfig($config)) {
                 $this->changeConfig($config['path'], $config['value'], $config['scope_type'], $config['scope_code']);
             }


### PR DESCRIPTION
There is no warning when doing something like

``` php
        $this->configManager->changeConfigs(
            [
                [
                'value' => $value,
                'path' => 'some/config/path',
                ]
            ]
        );
```

The above config is not set, as it's not valid: it's missing 2 keys - `scope_type` and `scope_config`.

This has bitten me two times now. 
Either this (setting defaults) or open the doors of hell so that the developer knows something's wrong (an exception maybe).
